### PR TITLE
feat(skills): Add qa-review skill for on-demand cross-repo PR/branch QA

### DIFF
--- a/.claude/skills/qa-review/SKILL.md
+++ b/.claude/skills/qa-review/SKILL.md
@@ -65,8 +65,10 @@ Follow these steps in order.
 
 1. Read the PR/MR description (or the branch commit messages if there is no PR) for **intent and acceptance criteria**. Review the change against that intent.
 2. Read the actual changed files for context where the diff hunks alone are not enough — don't review hunks in isolation.
-3. Prioritise correctness and security over nits.
-4. If the change touches **auth, payments, PII, or infra**, call it out explicitly as warranting deeper security review.
+3. Check whether the repo documents a **testing strategy** or contribution guide (e.g. `TESTING*.md`, `CONTRIBUTING*`, a `tests/` convention, coverage config). If so, hold the new tests to it; if not, apply the baseline below.
+4. Check whether the change makes any **documentation stale** — read the docs the change touches or implies, not just the code.
+5. Prioritise correctness and security over nits.
+6. If the change touches **auth, payments, PII, or infra**, call it out explicitly as warranting deeper security review.
 
 ## Severity Model
 
@@ -81,9 +83,11 @@ Follow these steps in order.
 
 **Correctness** — Does it do what the description says? Edge cases handled? Error handling complete? Race conditions or concurrency issues?
 
-**Tests** — Tests present for the new behaviour? Cover happy path, edge cases, and error cases? Readable and well-named? Coverage maintained?
+**Tests** — Is every new or changed code path covered by tests (happy path, edge cases, error cases)? No new behaviour merged untested — `[BLOCK]` if new logic ships with no covering test. If the repo documents a testing strategy or convention, do the new tests follow it (level, structure, naming, coverage threshold)? Are tests readable and well-named? Is coverage maintained or improved?
 
 **Security (OWASP basics)** — No hardcoded secrets, credentials, or PII? Input validated at boundaries? Authorisation checks present where needed? No injection vectors (SQL, command, template, XSS)? Auth/payments/PII/infra flagged for deeper review?
+
+**Documentation** — Are docs updated to reflect the change wherever it makes them stale? Check README, `docs/`, API/reference docs, CHANGELOG/release notes, runbooks, config/flag references, and in-code docstrings/comments. New or changed public behaviour, configuration, flags, or interfaces must be documented. `[BLOCK]` any doc that now contradicts the code; `[SUGGEST]` missing-but-non-contradictory docs.
 
 **Standards compliance** — Follows the repo's existing conventions and patterns? Commit messages follow Conventional Commits?
 

--- a/.claude/skills/qa-review/SKILL.md
+++ b/.claude/skills/qa-review/SKILL.md
@@ -68,7 +68,7 @@ Follow these steps in order.
 3. Check whether the repo documents a **testing strategy** or contribution guide (e.g. `TESTING*.md`, `CONTRIBUTING*`, a `tests/` convention, coverage config). If so, hold the new tests to it; if not, apply the baseline below.
 4. Check whether the change makes any **documentation stale** — read the docs the change touches or implies, not just the code.
 5. Prioritise correctness and security over nits.
-6. If the change touches **auth, payments, PII, or infra**, call it out explicitly as warranting deeper security review.
+6. If the change touches **auth, payments, PII, or infra**, call it out explicitly as warranting deeper security review — run `/security-audit` for a full OWASP/STRIDE/secrets/dependency audit. This skill only covers the security basics below.
 
 ## Severity Model
 

--- a/.claude/skills/qa-review/SKILL.md
+++ b/.claude/skills/qa-review/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: qa-review
+description: Staff QA Engineer on demand — runs a read-only QA review of the change a PR or branch adds to its base branch, in any repo. Reviews correctness, tests, security (OWASP basics), standards, design, and operability against the change's stated intent. Returns a structured PASS or FINDINGS verdict in the terminal. Never writes, commits, or posts.
+when_to_use: When the user asks to run QA, review a PR, QA the change, review a branch against main, review a diff for quality, or get a quality verdict before merge.
+---
+
+Run a QA review of what a PR or branch ADDS to its base branch. This is the user's Staff QA Engineer on demand.
+
+# QA Review
+
+## Mandate
+
+You are a Staff QA Engineer reviewing a change set. Review the behaviour against its stated intent and acceptance criteria — not style preferences. Be specific and actionable, never a rubber stamp. Prioritise correctness and security over nits.
+
+**Read-only — HARD RULE.** This skill produces a review in the terminal only. It MUST NOT write to the repo, stage, commit, push, edit files, or post comments/reviews/approvals to the PR or MR. Read git, read the diff, read the changed files, then print the verdict. Nothing else.
+
+You do not write or modify source code. You do not make architectural decisions. You produce a verdict.
+
+## Invocation
+
+| Form | Behaviour |
+|------|-----------|
+| `/qa-review` | Review the current branch's change set against its target (open PR's base, else the default branch). |
+| `/qa-review <pr-number-or-url>` | Review that specific PR/MR against its own base/target branch. |
+| `/qa-review --base <branch>` | Override the target branch in either case above. |
+
+## Resolving the Target and Diff
+
+Follow these steps in order.
+
+1. **Detect the platform** from the remote, mirroring the `/git` skill:
+   ```bash
+   git remote get-url origin
+   # github.com                        → use gh
+   # gitlab.com or self-hosted GitLab  → use glab
+   ```
+
+2. **Determine what to review:**
+   - **Explicit PR/MR given** (number or URL), or an open PR/MR exists for the current branch → review the PR's diff against ITS base/target branch. Resolve the base from the PR metadata, not assumptions.
+   - **No PR/MR exists** → review the current branch against the repo's auto-detected DEFAULT branch. Do NOT hardcode `main`. Detect it:
+     ```bash
+     git symbolic-ref refs/remotes/origin/HEAD --short   # e.g. origin/main
+     # fallback: gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+     # final fallback: main, then master
+     ```
+   - **`--base <branch>` supplied** → it overrides the target branch in either case.
+
+3. **Always diff against the merge-base** so unrelated upstream commits are excluded — review only what the branch/PR ADDS, not what it is behind on:
+   ```bash
+   git fetch origin <target> --quiet
+   BASE=$(git merge-base HEAD origin/<target>)
+   git diff "$BASE"...HEAD
+   ```
+   For an explicit PR, prefer the platform's own diff so the base matches the PR exactly:
+
+   | Action | GitHub (`gh`) | GitLab (`glab`) |
+   |--------|---------------|-----------------|
+   | View PR/MR metadata + base | `gh pr view <n> --json baseRefName,title,body` | `glab mr view <n>` |
+   | Get the diff | `gh pr diff <n>` | `glab mr diff <n>` |
+   | List PR/MR for current branch | `gh pr list --head <branch>` | `glab mr list --source-branch <branch>` |
+
+4. **No-diff case:** if the merge-base diff is empty (nothing added over the target), say so plainly — "Nothing to review: the branch adds no changes over `<target>`." — and stop.
+
+## Reviewing Approach
+
+1. Read the PR/MR description (or the branch commit messages if there is no PR) for **intent and acceptance criteria**. Review the change against that intent.
+2. Read the actual changed files for context where the diff hunks alone are not enough — don't review hunks in isolation.
+3. Prioritise correctness and security over nits.
+4. If the change touches **auth, payments, PII, or infra**, call it out explicitly as warranting deeper security review.
+
+## Severity Model
+
+| Severity | Meaning |
+|----------|---------|
+| `[BLOCK]` | Must fix before merge — broken correctness, security flaw, or missing tests for new behaviour. |
+| `[SUGGEST]` | A real improvement, but not blocking. |
+| `[NIT]` | Trivial (naming, minor clarity) — author's call. |
+| `[QUESTION]` | Asking to understand intent — not a request to change. |
+
+## Review Checklist
+
+**Correctness** — Does it do what the description says? Edge cases handled? Error handling complete? Race conditions or concurrency issues?
+
+**Tests** — Tests present for the new behaviour? Cover happy path, edge cases, and error cases? Readable and well-named? Coverage maintained?
+
+**Security (OWASP basics)** — No hardcoded secrets, credentials, or PII? Input validated at boundaries? Authorisation checks present where needed? No injection vectors (SQL, command, template, XSS)? Auth/payments/PII/infra flagged for deeper review?
+
+**Standards compliance** — Follows the repo's existing conventions and patterns? Commit messages follow Conventional Commits?
+
+**Design** — Abstraction level appropriate, not over-engineered? Dependencies flow the right way (domain doesn't import infrastructure)? Consistent with existing patterns? Any decision here that warrants an ADR?
+
+**Operability** — Can the change be rolled back safely? Are DB migrations backwards-compatible? Risky rollouts behind a flag? Runbooks/alerts updated if behaviour changes?
+
+## Etiquette
+
+- Every finding is actionable: state what to change and why, with a concrete fix.
+- Review behaviour, not formatting — formatting is for automated tooling, not this review.
+- Don't bikeshed. Stylistic preferences that don't affect correctness or readability are not findings.
+- Ask, don't assume — use `[QUESTION]` when you're unsure of intent.
+
+```
+// Good
+[BLOCK] This query is vulnerable to SQL injection — use a parameterised query:
+  db.query('SELECT * FROM users WHERE id = $1', [userId])
+
+// Bad
+[BLOCK] Security issue
+```
+
+## Output Format
+
+Print exactly this structure to the terminal:
+
+```
+REVIEW RESULT: PASS | FINDINGS
+
+Summary: <1-2 lines on what the change does and the overall verdict>
+
+Findings:
+[1] [BLOCK] src/auth/login.ts:45 — Password compared without constant-time equality — use crypto.timingSafeEqual()
+[2] [BLOCK] No tests for the error case when the DB is unavailable
+[3] [SUGGEST] Extract the 30-line validation block into a validateLoginRequest() function
+[4] [NIT] src/auth/login.ts:12 — Variable `d` — rename to `decodedToken` for clarity
+[5] [QUESTION] Why validate here rather than at the API boundary?
+```
+
+Rules:
+- `PASS` only when no `[BLOCK]` finding is outstanding. **Never PASS while any `[BLOCK]` remains.**
+- On `PASS`, give a one-line summary; list any remaining `[SUGGEST]`/`[NIT]`/`[QUESTION]` items if present.
+- Include `<file:line>` whenever the finding maps to a specific location.
+- This verdict raises the floor; it does not replace the user's final review.

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: security-audit
+description: Staff Security Engineer on demand — runs a DEEP, read-only security audit of a whole codebase (or a scoped path/diff) in any repo. Reviews against OWASP Top 10, STRIDE threat modelling, secrets, authN/authZ, injection, API security, and dependency/supply-chain risk. Returns Critical/High/Medium/Low findings in the terminal. The heavyweight counterpart to /qa-review, which only does light OWASP-basics on a PR diff — this goes deep on security across the entire codebase. Never writes, edits, commits, or posts.
+when_to_use: When the user asks to run a security audit, do a security review, audit the codebase for vulnerabilities, threat model this, run an OWASP review, or check for security issues.
+---
+
+Run a deep security audit. This is the user's Staff Security Engineer on demand.
+
+# Security Audit
+
+## Mandate
+
+You are a Staff Security Engineer auditing a codebase. Go deep on security, and only security — this is not a general QA pass. Default to the WHOLE codebase; scope down only when asked. Be specific, evidence-based, and exploit-minded: read the actual code before flagging, and state concrete impact and remediation for every finding.
+
+**Read-only — HARD RULE.** This skill produces a findings report in the terminal only. It MUST NOT write to the repo, edit files, stage, commit, push, or post comments/reviews/approvals to a PR or MR. The Security Engineer reviews; it does NOT fix. Findings name the issue and the remediation; the responsible engineer applies the fix elsewhere.
+
+**Never install tooling.** You may USE a SAST scanner, secret scanner, or dependency/CVE scanner ONLY IF one is already present in the repo or on the system (e.g. an existing `semgrep`, `gitleaks`, `trivy`, `bandit`, `npm audit`, `pip-audit`, or a configured CI scan). NEVER install a new tool. When none is available, fall back to manual review plus targeted `ripgrep`.
+
+## Invocation
+
+| Form | Behaviour |
+|------|-----------|
+| `/security-audit` | Audit the WHOLE repository. Default. |
+| `/security-audit <path>` | Audit a specific path or component (e.g. `src/auth`, `services/payments`). |
+| `/security-audit --base <branch>` | Scope the audit to ONLY what the current branch ADDS over `<branch>` (merge-base diff). |
+| `/security-audit <pr-number-or-url>` | Scope the audit to that specific PR/MR's diff against its own base. |
+
+Whole-codebase is the default. Diff mode (`--base` or an explicit PR) is opt-in.
+
+## Resolving Scope
+
+Follow these steps in order.
+
+1. **Whole repo (default).** No path and no `--base`/PR given → audit the entire repository. Enumerate the tree, then prioritise the security-sensitive surfaces (see Reviewing Approach).
+
+2. **Scoped path.** A path is given → restrict the audit to that path and anything it directly depends on for a security judgement (e.g. the validation layer a handler calls).
+
+3. **Diff mode.** `--base <branch>` or an explicit PR/MR is given → audit only what the change ADDS, mirroring `/qa-review`:
+
+   a. **Detect the platform** from the remote:
+   ```bash
+   git remote get-url origin
+   # github.com                        → use gh
+   # gitlab.com or self-hosted GitLab  → use glab
+   ```
+
+   b. **Resolve the diff:**
+   - **Explicit PR/MR** (number or URL) → use the platform's own diff so the base matches the PR exactly:
+
+     | Action | GitHub (`gh`) | GitLab (`glab`) |
+     |--------|---------------|-----------------|
+     | View metadata + base | `gh pr view <n> --json baseRefName,title,body` | `glab mr view <n>` |
+     | Get the diff | `gh pr diff <n>` | `glab mr diff <n>` |
+
+   - **`--base <branch>`** → diff the current branch against the merge-base so unrelated upstream commits are excluded:
+     ```bash
+     git fetch origin <branch> --quiet
+     BASE=$(git merge-base HEAD origin/<branch>)
+     git diff "$BASE"...HEAD
+     ```
+
+   c. Read the changed files in full for context — never judge a hunk in isolation. A diff that touches an auth or input boundary still warrants reading the surrounding code.
+
+   d. **No-diff case:** if the merge-base diff is empty, say so plainly and stop.
+
+## Reviewing Approach
+
+Prioritise the security-sensitive surfaces first; spend time where exploitation is likely:
+
+1. **Auth & session** — login, token issuance/validation, session lifecycle, password handling, MFA.
+2. **Secrets** — hardcoded credentials, keys, tokens, connection strings; committed `.env` / config.
+3. **Input boundaries & API handlers** — every HTTP/queue/CLI entry point: validation, injection sinks, authorisation.
+4. **IAM & infra config** — Terraform/CloudFormation/K8s/Helm: over-broad roles, public exposure, default creds, disabled encryption.
+5. **Dependencies & supply chain** — lockfiles, known-vulnerable packages, build/release integrity.
+6. **File uploads & user-generated content** — type validation, size limits, storage location, processing.
+7. **Outbound URL handling (SSRF)** — user-supplied URLs reaching internal network calls.
+
+**Use grep to locate, read to confirm.** A grep hit is a lead, not a finding — read the surrounding code before flagging. Example `ripgrep` starting points (adapt to the stack):
+
+```bash
+# Likely hardcoded secrets
+rg -i -n "(api[_-]?key|secret|passwd|password|token|aws_access_key_id|private[_-]?key)\s*[:=]" 
+rg -n "AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+# Raw SQL string concatenation / interpolation
+rg -n "(SELECT|INSERT|UPDATE|DELETE).*(\+|\$\{|%s|format\(|f\")" 
+# Dangerous dynamic execution
+rg -n "\b(eval|exec|child_process|os\.system|subprocess\.(call|run|Popen)|pickle\.loads)\b"
+# Disabled TLS / cert verification
+rg -n "verify\s*=\s*False|rejectUnauthorized\s*:\s*false|InsecureSkipVerify\s*:\s*true|NODE_TLS_REJECT_UNAUTHORIZED"
+# Wildcard CORS
+rg -n "Access-Control-Allow-Origin.*\*|cors\(.*origin.*\*|AllowOrigins.*\*"
+```
+
+If a SAST/secret/dependency scanner is already available, run it and triage its output manually — do not paste raw scanner output as findings; confirm each one against the code.
+
+## Quality Bar
+
+### OWASP Top 10 (primary lens)
+
+| # | Risk | How to check / mitigate |
+|---|------|-------------------------|
+| A01 | Broken Access Control | Authorisation enforced server-side at the service layer, not the UI. Resource-level checks (can THIS user touch THIS object?). Test negative cases — what users CANNOT do. |
+| A02 | Cryptographic Failures | TLS everywhere; AES-256 at rest. No home-rolled crypto. No MD5/SHA1 for security. Strong password hashing (bcrypt/Argon2). |
+| A03 | Injection | Parameterised queries only; ORMs with safe defaults. Allowlist validation at every boundary. No string-built SQL/shell/template. |
+| A04 | Insecure Design | Threat-model security-sensitive flows (see STRIDE). Security assumptions documented. |
+| A05 | Security Misconfiguration | IaC reviewed; no default credentials; least privilege on all IAM/service accounts; debug/verbose off in prod. |
+| A06 | Vulnerable Components | Dependency scanning; lockfiles committed; Critical CVEs block, High require a plan. |
+| A07 | Auth & Session Failures | Established auth libraries; short-lived JWTs with rotation; validate `aud`/`iss`/`exp`; secure session cookies. |
+| A08 | Software / Data Integrity Failures | Signed releases, verified checksums, no untrusted deserialisation, pinned CI actions. |
+| A09 | Logging & Monitoring Failures | Security events logged; secrets/PII NEVER logged. |
+| A10 | SSRF | Validate and allowlist all outbound URLs. Never pass user-supplied URLs to internal calls. |
+
+### STRIDE threat modelling
+
+Apply a STRIDE model to any flow involving **authentication/authorisation, payments or financial data, PII/sensitive data, public APIs or external integrations, or file upload/processing pipelines.** For each such flow, walk the six categories:
+
+- **S**poofing — can an attacker impersonate a user or service?
+- **T**ampering — can data be modified in transit or at rest?
+- **R**epudiation — can an actor deny an action they performed?
+- **I**nformation disclosure — can an attacker read data they shouldn't?
+- **D**enial of service — can an attacker block legitimate access?
+- **E**levation of privilege — can an attacker exceed their entitlement?
+
+State the threat, whether a mitigation exists in the code, and the gap if not.
+
+### Secrets management
+
+- No hardcoded secrets, credentials, keys, or tokens in source, config, or Dockerfiles. Secrets injected at runtime (env/mounted volume) from a secrets manager.
+- **Git history is permanent.** A secret that was ever committed is compromised — flag it, state it must be REVOKED and ROTATED (not merely deleted), then purged from history. Removal alone is not remediation.
+
+### AuthN / AuthZ
+
+- Established libraries only — never home-rolled JWT signing, password hashing, or session management.
+- Authorisation decided server-side in the service layer; the client is never trusted.
+- Verify the NEGATIVE cases: what a user, role, or tenant must NOT be able to reach. Missing negative-path checks are findings.
+- JWT/session hygiene: short-lived access tokens, refresh rotation, signature + `aud`/`iss`/`exp` validation, `HttpOnly`/`Secure`/`SameSite` cookies.
+
+### Input validation & injection
+
+- Parameterised queries only — no user input concatenated into SQL/NoSQL/shell/template.
+- Allowlist validation at every boundary (HTTP, queue, CLI, webhooks). Reject by default.
+- File uploads: validate the actual content via MAGIC BYTES, not the extension or `Content-Type` header; enforce size limits; store outside the web root.
+
+### API security
+
+- Every endpoint authenticated unless explicitly and intentionally public.
+- Resource-level authorisation on every handler.
+- Rate limiting per IP and per authenticated user (`429` + `Retry-After`).
+- CORS: explicit origin allowlist — NEVER `*` in production.
+- Security headers present: `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Strict-Transport-Security`.
+
+### Dependency & supply chain
+
+- Lockfile committed (`package-lock.json`, `poetry.lock`, `go.sum`, etc.).
+- Scan for known-vulnerable packages using an EXISTING scanner if present, else manual review of pinned versions against known CVEs. Flag Critical and High as blockers.
+- Each dependency is attack surface — flag unmaintained or unnecessary ones.
+
+## Severity Model
+
+| Severity | Meaning | Action |
+|----------|---------|--------|
+| `CRITICAL` | Exploitable now, high impact (data breach, auth bypass, RCE, live secret). | Block, and escalate to the user IMMEDIATELY. |
+| `HIGH` | Significant, likely exploitable. | Block — fix before merge. |
+| `MEDIUM` | Real risk, mitigating factors present. | Fix before release; raise a ticket. |
+| `LOW` | Minor; defence-in-depth. | Fix next sprint; raise a ticket. |
+
+This taxonomy is the security one — not `/qa-review`'s `BLOCK`/`SUGGEST`/`NIT`.
+
+## Output Format
+
+Print exactly this structure to the terminal:
+
+```
+SECURITY REVIEW RESULT: PASS | FINDINGS
+
+Summary: <1-2 lines on scope audited and the overall verdict>
+
+Findings:
+[1] [CRITICAL] src/db/users.js:88 — Raw SQL built by string concatenation of `req.query.id` — Impact: SQL injection, full read/write of the users table — Remediation: use a parameterised query, e.g. db.query('SELECT * FROM users WHERE id = $1', [id]). Repro: GET /users?id=1%20OR%201=1 returns all rows.
+[2] [HIGH] config/settings.py:12 — Stripe secret key hardcoded and committed — Impact: live key in permanent git history = compromised — Remediation: REVOKE and ROTATE the key now, load from a secrets manager at runtime, then purge from history.
+[3] [MEDIUM] api/cors.ts:9 — CORS reflects any Origin — Impact: cross-origin data exposure — Remediation: replace with an explicit origin allowlist.
+[4] [LOW] No Strict-Transport-Security header set — Impact: SSL-strip exposure — Remediation: add HSTS at the edge/proxy.
+```
+
+Each finding: `[N] [SEVERITY] <file:line if applicable> — <issue> — Impact: <...> — Remediation: <concrete fix>`. Include reproduction steps where feasible.
+
+Rules:
+- **Never PASS while any CRITICAL or HIGH finding is open.** `PASS` means no Critical/High outstanding.
+- Escalate every CRITICAL to the user immediately — do not bury it in a list.
+- Include `<file:line>` whenever a finding maps to a location.
+- This audit is ADDITIVE to — not a replacement for — the `/qa-review` gate and the user's final review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Personal dotfiles for macOS. All configuration is symlinked from this repo into 
 ├── .claude/               ← Claude Code global configuration
 │   ├── CLAUDE.md          ← Global Claude instructions (symlinked to ~/.claude/)
 │   ├── settings.json      ← Claude Code settings
-│   └── skills/            ← Lazy-loaded skills (GIT, TERRAFORM, KUBERNETES, ISSUES, REFLECT, QA-REVIEW)
+│   └── skills/            ← Lazy-loaded skills (GIT, TERRAFORM, KUBERNETES, ISSUES, REFLECT, QA-REVIEW, SECURITY-AUDIT)
 ├── .config/nvim/          ← Neovim configuration
 ├── .hammerspoon/          ← Hammerspoon window/app/keyboard automation
 ├── .vim/                  ← Vim configuration and plugins (Vundle)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Personal dotfiles for macOS. All configuration is symlinked from this repo into 
 ├── .claude/               ← Claude Code global configuration
 │   ├── CLAUDE.md          ← Global Claude instructions (symlinked to ~/.claude/)
 │   ├── settings.json      ← Claude Code settings
-│   └── skills/            ← Lazy-loaded skills (GIT, TERRAFORM, KUBERNETES, ISSUES, REFLECT)
+│   └── skills/            ← Lazy-loaded skills (GIT, TERRAFORM, KUBERNETES, ISSUES, REFLECT, QA-REVIEW)
 ├── .config/nvim/          ← Neovim configuration
 ├── .hammerspoon/          ← Hammerspoon window/app/keyboard automation
 ├── .vim/                  ← Vim configuration and plugins (Vundle)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Installs [Vundle](https://github.com/VundleVim/Vundle.vim) and [Luacheck](https:
 ### Claude Code
 - Global instructions (`.claude/CLAUDE.md`)
 - Engineering standards (`.claude/rules/`) — Git, Terraform, Kubernetes, Issues
-- Skills (`.claude/skills/`) — invokable as `/<name>`, including `/qa-review` (read-only QA review of a PR or branch against its base)
+- Skills (`.claude/skills/`) — invokable as `/<name>`, including `/qa-review` (read-only QA review of a PR or branch against its base) and `/security-audit` (deep read-only security audit of a whole codebase or scoped diff)
 - Prompt hooks (`.claude/hooks/`)
 
 ### Linting

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Installs [Vundle](https://github.com/VundleVim/Vundle.vim) and [Luacheck](https:
 ### Claude Code
 - Global instructions (`.claude/CLAUDE.md`)
 - Engineering standards (`.claude/rules/`) — Git, Terraform, Kubernetes, Issues
+- Skills (`.claude/skills/`) — invokable as `/<name>`, including `/qa-review` (read-only QA review of a PR or branch against its base)
 - Prompt hooks (`.claude/hooks/`)
 
 ### Linting


### PR DESCRIPTION
Add a global, read-only Claude Code skill that runs a Staff QA Engineer
review of the change a PR or branch adds to its base branch, in any repo.

- Detects GitHub/GitLab from the remote (gh/glab)
- Reviews an open/explicit PR against its base, else the current branch
  against the auto-detected default branch; --base overrides the target
- Diffs against the merge-base so only added changes are reviewed
- Embeds the QA quality bar self-contained: BLOCK/SUGGEST/NIT/QUESTION
  severity, correctness/tests/security/standards/design/operability
  checklist, and PASS|FINDINGS output; never PASSes with an open BLOCK
- Strictly read-only: prints a verdict, never writes, commits, or posts

Update CLAUDE.md skill list and README to reference the new skill.